### PR TITLE
Add refresh token support and token blacklist

### DIFF
--- a/auth/auth.go
+++ b/auth/auth.go
@@ -3,6 +3,7 @@ package auth
 import (
 	"errors"
 	"os"
+	"sync"
 	"time"
 
 	"github.com/gofiber/fiber/v2"
@@ -27,6 +28,28 @@ func CheckPasswordHash(password, hash string) bool {
 func GenUuid() string {
 	uuid := uuid.New()
 	return uuid.String()
+}
+
+var (
+	tokenBlacklist = struct {
+		sync.RWMutex
+		tokens map[string]struct{}
+	}{tokens: make(map[string]struct{})}
+)
+
+// BlacklistToken adds a token to the blacklist
+func BlacklistToken(token string) {
+	tokenBlacklist.Lock()
+	defer tokenBlacklist.Unlock()
+	tokenBlacklist.tokens[token] = struct{}{}
+}
+
+// IsTokenBlacklisted checks if a token is blacklisted
+func IsTokenBlacklisted(token string) bool {
+	tokenBlacklist.RLock()
+	defer tokenBlacklist.RUnlock()
+	_, exists := tokenBlacklist.tokens[token]
+	return exists
 }
 
 // GenerateJWT generates a new JWT for a given user
@@ -70,6 +93,47 @@ func ValidateJWT(tokenString string) (jwt.MapClaims, error) {
 	return nil, errors.New("invalid token")
 }
 
+// GenerateRefreshToken generates a refresh token with longer expiration
+func GenerateRefreshToken(userID uint) (string, error) {
+	secret := os.Getenv("JWT_REFRESH_SECRET")
+	if secret == "" {
+		return "", errors.New("JWT_REFRESH_SECRET is not set")
+	}
+
+	claims := jwt.MapClaims{
+		"user_id": userID,
+		"exp":     time.Now().Add(time.Hour * 24 * 7).Unix(),
+	}
+
+	token := jwt.NewWithClaims(jwt.SigningMethodHS256, claims)
+	return token.SignedString([]byte(secret))
+}
+
+// ValidateRefreshToken validates a refresh token
+func ValidateRefreshToken(tokenString string) (jwt.MapClaims, error) {
+	secret := os.Getenv("JWT_REFRESH_SECRET")
+	if secret == "" {
+		return nil, errors.New("JWT_REFRESH_SECRET is not set")
+	}
+
+	token, err := jwt.Parse(tokenString, func(token *jwt.Token) (interface{}, error) {
+		if _, ok := token.Method.(*jwt.SigningMethodHMAC); !ok {
+			return nil, errors.New("unexpected signing method")
+		}
+		return []byte(secret), nil
+	})
+
+	if err != nil {
+		return nil, err
+	}
+
+	if claims, ok := token.Claims.(jwt.MapClaims); ok && token.Valid {
+		return claims, nil
+	}
+
+	return nil, errors.New("invalid token")
+}
+
 // AuthMiddleware is a middleware to protect routes
 func AuthMiddleware(c *fiber.Ctx) error {
 	tokenString := c.Get("Authorization")
@@ -83,6 +147,13 @@ func AuthMiddleware(c *fiber.Ctx) error {
 	// The token is usually in the format "Bearer <token>"
 	if len(tokenString) > 7 && tokenString[:7] == "Bearer " {
 		tokenString = tokenString[7:]
+	}
+
+	if IsTokenBlacklisted(tokenString) {
+		return c.Status(fiber.StatusUnauthorized).JSON(fiber.Map{
+			"success": false,
+			"message": "Token has been revoked",
+		})
 	}
 
 	claims, err := ValidateJWT(tokenString)

--- a/main.go
+++ b/main.go
@@ -4,6 +4,7 @@ import (
 	"log"
 	"os"
 	"strconv"
+	"time"
 
 	"GO-X1/auth"
 	"GO-X1/connectDB"
@@ -48,9 +49,9 @@ func main() {
 		log.Println("Continuing without database connection...")
 	} else {
 		log.Println("Successfully connected to database!")
-		
+
 		// Auto migrate the schema
-		if err := db.AutoMigrate(&models.User{}); err != nil {
+		if err := db.AutoMigrate(&models.User{}, &models.RefreshToken{}); err != nil {
 			log.Printf("Warning: Failed to migrate database: %v", err)
 		} else {
 			log.Println("Database migration completed!")
@@ -97,13 +98,13 @@ func setupRoutes(app *fiber.App) {
 	// Health check
 	app.Get("/", healthCheck)
 	app.Get("/health", healthCheck)
-	
+
 	// Utility endpoints
 	app.Get("/uuid", generateUUID)
 
 	// API group
 	api := app.Group("/api/v1")
-	
+
 	// Auth routes
 	authRoutes := api.Group("/auth")
 	authRoutes.Post("/login", loginUser)
@@ -184,12 +185,38 @@ func loginUser(c *fiber.Ctx) error {
 		})
 	}
 
+	// Generate refresh token
+	refreshToken, err := auth.GenerateRefreshToken(user.ID)
+	if err != nil {
+		return c.Status(fiber.StatusInternalServerError).JSON(APIResponse{
+			Success: false,
+			Message: "Failed to generate refresh token",
+			Error:   err.Error(),
+		})
+	}
+
+	// Store refresh token
+	rt := models.RefreshToken{
+		Token:     refreshToken,
+		UserID:    user.ID,
+		ExpiresAt: time.Now().Add(7 * 24 * time.Hour),
+		Revoked:   false,
+	}
+	if err := db.Create(&rt).Error; err != nil {
+		return c.Status(fiber.StatusInternalServerError).JSON(APIResponse{
+			Success: false,
+			Message: "Failed to store refresh token",
+			Error:   err.Error(),
+		})
+	}
+
 	return c.JSON(APIResponse{
 		Success: true,
 		Message: "Login successful",
 		Data: models.LoginResponse{
-			Token: token,
-			User:  user.ToResponse(),
+			Token:        token,
+			RefreshToken: refreshToken,
+			User:         user.ToResponse(),
 		},
 	})
 }
@@ -200,8 +227,8 @@ func healthCheck(c *fiber.Ctx) error {
 		Success: true,
 		Message: "API is running successfully",
 		Data: map[string]interface{}{
-			"status": "healthy",
-			"service": "GO-X1 REST API",
+			"status":   "healthy",
+			"service":  "GO-X1 REST API",
 			"database": db != nil,
 		},
 	})

--- a/models/refresh_token.go
+++ b/models/refresh_token.go
@@ -1,0 +1,22 @@
+package models
+
+import (
+	"time"
+
+	"gorm.io/gorm"
+)
+
+// RefreshToken stores a refresh token and its state
+type RefreshToken struct {
+	ID        uint      `json:"id" gorm:"primaryKey"`
+	Token     string    `json:"token" gorm:"unique;not null"`
+	UserID    uint      `json:"user_id" gorm:"not null"`
+	ExpiresAt time.Time `json:"expires_at" gorm:"not null"`
+	Revoked   bool      `json:"revoked" gorm:"not null"`
+	CreatedAt time.Time `json:"created_at"`
+}
+
+// RevokeRefreshToken marks a refresh token as revoked
+func RevokeRefreshToken(db *gorm.DB, token string) error {
+	return db.Model(&RefreshToken{}).Where("token = ?", token).Update("revoked", true).Error
+}

--- a/models/user.go
+++ b/models/user.go
@@ -45,8 +45,9 @@ type LoginRequest struct {
 
 // LoginResponse is the response for a successful login
 type LoginResponse struct {
-	Token string       `json:"token"`
-	User  UserResponse `json:"user"`
+	Token        string       `json:"token"`
+	RefreshToken string       `json:"refresh_token"`
+	User         UserResponse `json:"user"`
 }
 
 // ToResponse converts User to UserResponse


### PR DESCRIPTION
## Summary
- add refresh token generation/validation with separate secret and long expiry
- store refresh tokens in database and expose revocation helper
- blacklist access tokens and verify in auth middleware

## Testing
- `go test ./...`
- `go vet ./...`
- `go build ./...`


------
https://chatgpt.com/codex/tasks/task_e_689bf05084dc832fa182f45fd3563ce4